### PR TITLE
Align to newer knitr and engine_output()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,3 +15,4 @@ Maintainer: Yihui Xie <xie@yihui.name>
 License: GPL
 URL: https://github.com/yihui/runr
 BugReports: https://github.com/yihui/runr/issues
+RoxygenNote: 7.2.1

--- a/R/V8engine.R
+++ b/R/V8engine.R
@@ -31,16 +31,16 @@ V8engine <- function(options) {
     }
   }
   code <- as.character(c(options$code))
-  if(!.context$validate(code)) stop("unvalid javascript code")
+  if(!.context$validate(code)) stop("invalid javascript code")
   if(!is.element(options$results, c("hide", "last"))){
     code <- group_src_V8(code, .context)
     output <- sapply(code, function(code) .context$eval(code))
-    code <-  sapply(code, function(code) knitr:::wrap.source(list(src= paste(code, collapse = "\n")), options))
+    code <-  sapply(code, function(code) knitr:::wrap_rmd(text = paste(code, collapse = "\n")))
   }else{
     if(options$results=="last") output <- .context$eval(code)
-    code <-  knitr:::wrap.source(list(src= paste(code, collapse = "\n")), options)
+    code <- knitr:::wrap_rmd(text = paste(code, collapse = "\n"))
     if(options$results=="hide") return(code)
-    return(c(code, knitr:::wrap.character(output, options)))
+    return(c(code, knitr:::msg_wrap(output, type = "message", options = options)))
   }
-  return(c(sapply(seq_along(code), function(i) c(code[i], knitr:::wrap.character(output[i], options)))))
+  knitr::engine_output(options, code, output)
 }


### PR DESCRIPTION
This is a bit of a hack (I don't fully understand the intricacies of knitr engines) but it gets the V8 engine running again. knitr no longer has a `wrap.source` and formats outputs slightly differently, so this re-aligns to that.

I want this so that I can chain together javascript knitr chunks (the 'node' engine runs them individually as `node -e CODE`) and came across your PR to `runr`. This should also update that PR.

Thanks!